### PR TITLE
experimental 

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -23,7 +23,7 @@
 architect:
   - h1alexbel
 docker:
-  image: yegor256/rultor-image:1.13.0
+  image: _/rust:latest
 assets:
   credentials: l3r8yJ/home#assets/crates-credentials
 install: |


### PR DESCRIPTION
I've replaced image with [official image](https://hub.docker.com/_/rust)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Docker image in the `.rultor.yml` file to use `_/rust:latest` instead of `yegor256/rultor-image:1.13.0`.

### Detailed summary
- Updated Docker image to `_/rust:latest` in `.rultor.yml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->