### PR TITLE
feat(rultor): install toolchain first

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -27,7 +27,8 @@ docker:
 assets:
   credentials: l3r8yJ/home#assets/crates-credentials
 install: |
-  sudo rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
+  rustup install nightly-x86_64-unknown-linux-gnu
+  rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
   cargo install --version 1.30.1 just
 merge:
   script: |


### PR DESCRIPTION
- **feat(rultor): install it first**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the installation process in the `.rultor.yml` file by switching from manually installing Rust nightly to using `rustup install` command.

### Detailed summary
- Updated Rust nightly installation process to use `rustup install` command
- Added `rustup install` command for nightly toolchain
- Added `cargo install just` command for version 1.30.1

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->