### PR TITLE
feat(rultor): --color after

### DIFF
--- a/justfile
+++ b/justfile
@@ -55,6 +55,6 @@ rultor:
    sudo npm install @openapitools/openapi-generator-cli -g && \
     sudo openapi-generator-cli generate -i github.yml -g rust -o .
   cargo --color=never test -vv
-  cargo --color=never +nightly fmt --check
+  cargo +nightly fmt --check -- --color=never
   cargo doc --no-deps
   cargo clippy


### PR DESCRIPTION
- **feat(rultor): --color after**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the formatting command in the Justfile to use nightly Rust fmt with color option disabled.

### Detailed summary
- Updated `justfile` to use `cargo +nightly fmt --check -- --color=never` command for formatting.
- Ensured consistent formatting by disabling color output for Rust fmt.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->