### PR TITLE
74

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,9 +28,6 @@ edition = "2021"
 name = "cli"
 path = "src/main.rs"
 
-[lints.rust]
-missing_docs = "deny"
-
 [lints.clippy]
 unwrap_used = "deny"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,6 +28,12 @@ edition = "2021"
 name = "cli"
 path = "src/main.rs"
 
+[lints.rust]
+missing_docs = "deny"
+
+[lints.clippy]
+unwrap_used = "deny"
+
 [dev-dependencies]
 assert_cmd = "2.0.14"
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -37,6 +37,9 @@ path = "src/lib.rs"
 [lints.rust]
 missing_docs = "deny"
 
+# @todo #74:30min\DEV Find way to spread clippy config
+#  We need to find way to spread clippy/rustfmt configuration
+#  through all workspaces to reduce duplications in child workspaces.
 [lints.clippy]
 unwrap_used = "deny"
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -37,6 +37,9 @@ path = "src/lib.rs"
 [lints.rust]
 missing_docs = "deny"
 
+[lints.clippy]
+unwrap_used = "deny"
+
 [dependencies]
 openapi = { path = "../github-mirror" }
 anyhow = "1.0.86"

--- a/server/src/handlers/home.rs
+++ b/server/src/handlers/home.rs
@@ -24,8 +24,9 @@ use axum::response::IntoResponse;
 use axum::Json;
 use log::debug;
 
-use crate::ServerConfig;
 use openapi::models::MetaRoot200Response;
+
+use crate::ServerConfig;
 
 /// Home handler.
 pub async fn home(State(config): State<ServerConfig>) -> impl IntoResponse {
@@ -188,8 +189,6 @@ pub async fn home(State(config): State<ServerConfig>) -> impl IntoResponse {
 
 #[cfg(test)]
 mod tests {
-    use crate::handlers::home::home;
-    use crate::ServerConfig;
     use anyhow::Result;
     use axum::body::to_bytes;
     use axum::extract::State;
@@ -197,6 +196,9 @@ mod tests {
     use hamcrest::{equal_to, is, HamcrestMatcher};
     use serde_json::{from_str, Value};
     use tokio::fs;
+
+    use crate::handlers::home::home;
+    use crate::ServerConfig;
 
     const BYTES_READ_LIMIT: usize = 10000;
 
@@ -219,25 +221,21 @@ mod tests {
 
     #[tokio::test]
     async fn returns_root_response() -> Result<()> {
-        let actual: Value = from_str(
-            &String::from_utf8(
-                to_bytes(
-                    IntoResponse::into_response(
-                        home(State(ServerConfig {
-                            host: String::from("test"),
-                            port: 1234,
-                        }))
-                        .await,
-                    )
-                    .into_body(),
-                    BYTES_READ_LIMIT,
+        let actual: Value = from_str(&String::from_utf8(
+            to_bytes(
+                IntoResponse::into_response(
+                    home(State(ServerConfig {
+                        host: String::from("test"),
+                        port: 1234,
+                    }))
+                    .await,
                 )
-                .await
-                .unwrap()
-                .to_vec(),
+                .into_body(),
+                BYTES_READ_LIMIT,
             )
-            .unwrap(),
-        )
+            .await?
+            .to_vec(),
+        )?)
         .expect("Failed to parse JSON");
         assert_that!(
             actual.to_string(),

--- a/server/src/objects/user.rs
+++ b/server/src/objects/user.rs
@@ -55,9 +55,6 @@ impl User {
 //  apply it to the storage. Keep in mind that application function in the
 //  storage should be thread-safe (as well as #xml function). Don't forget to
 //  create unit tests that prove that.
-// @todo #17:30min Configure clippy to reject code with #unwrap().
-//  We should prohibit to use #unwrap() function in our code. Let's configure
-//  clippy tool in the respective manner and get rid of all #unwrap() calls.
 impl User {
     /// Save user.
     pub async fn save(self) -> Result<()> {

--- a/server/src/objects/user.rs
+++ b/server/src/objects/user.rs
@@ -59,7 +59,7 @@ impl User {
     /// Save user.
     pub async fn save(self) -> Result<()> {
         info!("saving user @{}", self.username);
-        let xml = to_string(&self).unwrap();
+        let xml = to_string(&self)?;
         debug!("XMLed user: {}", xml);
         Ok(())
     }

--- a/server/src/xml/storage.rs
+++ b/server/src/xml/storage.rs
@@ -109,7 +109,7 @@ mod tests {
         let temp = TempDir::new("temp")?;
         let path = temp.path().join("fakehub.xml");
         Storage::new(path.to_str());
-        let xml = fs::read_to_string(path).unwrap();
+        let xml = fs::read_to_string(path)?;
         let expected = "<root>\n<github><users/></github>\n</root>\n";
         assert_that!(xml, is(equal_to(String::from(expected))));
         Ok(())

--- a/server/tests/routes_it.rs
+++ b/server/tests/routes_it.rs
@@ -47,8 +47,7 @@ mod routes_its {
         let response = reqwest::Client::new()
             .get(format!("http://localhost:{}/", port))
             .send()
-            .await
-            .unwrap();
+            .await?;
         assert_that!(response.status().as_u16(), is(equal_to(200)));
         Ok(())
     }


### PR DESCRIPTION
closes #74 

@h1alexbel take a look, please 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing clippy configuration to reject `unwrap()` calls throughout the codebase, and minor code improvements.

### Detailed summary
- Added `unwrap_used = "deny"` in `lints.clippy` section in `Cargo.toml`
- Replaced `unwrap()` calls with `?` operator to handle errors gracefully
- Removed unnecessary imports and commented-out code
- Updated comments and documentation for clarity

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->