### PR TITLE
chore: zerocracy write-all

### DIFF
--- a/.github/workflows/zerocracy.yml
+++ b/.github/workflows/zerocracy.yml
@@ -27,6 +27,7 @@ name: zerocracy
 concurrency:
   group: zerocracy
   cancel-in-progress: false
+permissions: write-all
 jobs:
   zerocracy:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
chore: zerocracy.yml write-all permissions

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating permissions in the `zerocracy.yml` workflow file to `write-all`.

### Detailed summary
- Updated permissions to `write-all` in the `zerocracy.yml` workflow file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->