### PR TITLE
feat(#82): --verbose, puzzle for server shutdown

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,6 +43,8 @@ clap_complete_nushell = { version = "4.5.1", optional = true }
 server = { path = "../server" }
 tokio = { version = "1.0.0", features = ["rt", "rt-multi-thread", "macros"] }
 log = "0.4.21"
+tracing-subscriber = "0.3.18"
+tracing = "0.1.40"
 
 [features]
 default = ["cli"]

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -47,4 +47,7 @@ pub(crate) struct StartArgs {
     /// The port to run
     #[arg(short, long, default_value_t = 3000)]
     pub(crate) port: usize,
+    /// Verbose output.
+    #[arg(short, long, default_value = "false")]
+    pub(crate) verbose: bool,
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,6 +33,13 @@ async fn main() {
     let args = Args::parse();
     match args.command {
         Command::Start(start_args) => {
+            if start_args.verbose {
+                tracing_subscriber::fmt()
+                    .with_max_level(tracing::Level::DEBUG)
+                    .init()
+            } else {
+                tracing_subscriber::fmt::init();
+            }
             info!("Starting server on port {}", start_args.port);
             let server = Server::new(start_args.port);
             match server.start().await {

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -47,6 +47,8 @@ fn outputs_start_opts() -> Result<()> {
     let output = str::from_utf8(bytes)?;
     assert!(output.contains("--port"));
     assert!(output.contains("The port to run [default: 3000]"));
+    assert!(output.contains("--verbose"));
+    assert!(output.contains("Verbose output"));
     Ok(())
 }
 
@@ -65,5 +67,22 @@ fn starts_server() -> Result<()> {
     let bytes = assertion.get_output().stdout.as_slice();
     let output = str::from_utf8(bytes)?;
     assert!(output.contains("Server started successfully on port 8080"));
+    Ok(())
+}
+
+// @todo #82:30min Enable runs_in_verbose_mode test.
+//  We should enable this test right after we find out how to shutdown the server
+//  in test. This problem is similar to
+//  https://github.com/h1alexbel/fakehub/issues/76.
+#[test]
+#[ignore]
+fn runs_in_verbose_mode() -> Result<()> {
+    let assertion = Command::cargo_bin("cli")?
+        .arg("start")
+        .arg("--verbose")
+        .assert();
+    let bytes = assertion.get_output().stdout.as_slice();
+    let output = str::from_utf8(bytes)?;
+    assert!(output.contains("DEBUG"));
     Ok(())
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -55,6 +55,5 @@ axum = "0.7.5"
 log = { version = "0.4.21", features = [] }
 env_logger = "0.11.3"
 tempdir = "0.3.7"
-tracing-subscriber = "0.3.18"
 hamcrest = "0.1.5"
 reqwest = "0.12.5"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -85,7 +85,6 @@ pub struct ServerConfig {
 impl Server {
     /// Start a server.
     pub async fn start(self) -> Result<()> {
-        tracing_subscriber::fmt::init();
         Storage::new(Some("fakehub.xml"));
         let addr: String = format!("0.0.0.0:{}", self.port);
         let started: io::Result<TcpListener> = TcpListener::bind(addr.clone()).await;


### PR DESCRIPTION
@l3r8yJ take a look, please

closes #82

<!-- start pr-codex -->

---

## PR-Codex overview
**Focus:** Add verbose output option and integrate tracing library for enhanced logging.

### Detailed summary
- Added `verbose` flag in CLI args for verbose output.
- Integrated `tracing-subscriber` and `tracing` in Cargo.toml for advanced logging.
- Updated server start function to initialize tracing based on `verbose` flag.
- Added test for running in verbose mode.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->