### PR TITLE
feat(#137): user.extra, json_user

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -58,3 +58,6 @@ tempdir = "0.3.7"
 hamcrest = "0.1.5"
 reqwest = "0.12.5"
 uuid = { version = "1.10.0", features = ["v4", "fast-rng", "macro-diagnostics", ] }
+md-5 = "0.11.0-pre.4"
+hex-literal = "0.4.1"
+chrono = "0.4.38"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -61,3 +61,4 @@ uuid = { version = "1.10.0", features = ["v4", "fast-rng", "macro-diagnostics", 
 md-5 = "0.11.0-pre.4"
 hex-literal = "0.4.1"
 chrono = "0.4.38"
+rand = "0.8.5"

--- a/server/src/handlers/cursor.rs
+++ b/server/src/handlers/cursor.rs
@@ -19,11 +19,32 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-/// Home handler.
-pub mod home;
-/// Handler for internal user registration.
-pub mod register_user;
-/// Slashed Cursor.
-pub mod sh_cursor;
+
 /// Cursor.
-pub mod cursor;
+#[derive(Clone)]
+pub struct Cursor {
+    pub(crate) base: String,
+}
+
+impl Cursor {
+    /// As string.
+    pub fn as_string(self) -> String {
+        self.base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    
+    use anyhow::Result;
+    use hamcrest::{equal_to, is, HamcrestMatcher};
+    use crate::handlers::cursor::Cursor;
+
+    #[test]
+    fn prints_current() -> Result<()> {
+        let expected = String::from("test");
+        let cursor = Cursor { base: expected.clone() };
+        assert_that!(cursor.as_string(), is(equal_to(expected)));
+        Ok(())
+    }
+}

--- a/server/src/handlers/cursor.rs
+++ b/server/src/handlers/cursor.rs
@@ -23,7 +23,8 @@
 /// Cursor.
 #[derive(Clone)]
 pub struct Cursor {
-    pub(crate) base: String,
+    /// Base.
+    pub base: String,
 }
 
 impl Cursor {
@@ -35,15 +36,17 @@ impl Cursor {
 
 #[cfg(test)]
 mod tests {
-    
+
+    use crate::handlers::cursor::Cursor;
     use anyhow::Result;
     use hamcrest::{equal_to, is, HamcrestMatcher};
-    use crate::handlers::cursor::Cursor;
 
     #[test]
     fn prints_current() -> Result<()> {
         let expected = String::from("test");
-        let cursor = Cursor { base: expected.clone() };
+        let cursor = Cursor {
+            base: expected.clone(),
+        };
         assert_that!(cursor.as_string(), is(equal_to(expected)));
         Ok(())
     }

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -19,11 +19,11 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+/// Cursor.
+pub mod cursor;
 /// Home handler.
 pub mod home;
 /// Handler for internal user registration.
 pub mod register_user;
 /// Slashed Cursor.
 pub mod sh_cursor;
-/// Cursor.
-pub mod cursor;

--- a/server/src/handlers/register_user.rs
+++ b/server/src/handlers/register_user.rs
@@ -35,15 +35,15 @@ pub async fn register_user(
     State(config): State<ServerConfig>,
     Json(payload): Json<User>,
 ) -> Result<StatusCode, String> {
-    let newcomer = User::new(payload.username.clone());
+    let mut newcomer = User::new(payload.login.clone());
     let fakehub = config.fakehub;
     let github = fakehub.main();
     match newcomer.register_in(&mut github.clone()) {
         Ok(_) => {
-            info!("New user is here. Hello @{}", newcomer.username);
+            info!("New user is here. Hello @{}", newcomer.login);
             Ok(StatusCode::CREATED)
         }
-        Err(e) => Err(format!("Can't register user @{}: {}", newcomer.username, e)),
+        Err(e) => Err(format!("Can't register user @{}: {}", newcomer.login, e)),
     }
 }
 

--- a/server/src/handlers/sh_cursor.rs
+++ b/server/src/handlers/sh_cursor.rs
@@ -28,7 +28,10 @@ use crate::handlers::cursor::Cursor;
 /// use server::handlers::cursor::Cursor;
 /// use server::handlers::sh_cursor::ShCursor;
 ///
-/// let url = ShCursor::new(Cursor::new(String::from("http://localhost:3000")), String::from("repos")).as_string();
+/// let url = ShCursor::new(
+///     Cursor {base: String::from("http://localhost:3000") },
+///     String::from("repos")
+/// ).as_string();
 /// assert_that!(url, is(equal_to(String::from("http://localhost:3000/repos"))));
 /// ```
 pub struct ShCursor {

--- a/server/src/handlers/sh_cursor.rs
+++ b/server/src/handlers/sh_cursor.rs
@@ -1,0 +1,74 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2024 Aliaksei Bialiauski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+use crate::handlers::cursor::Cursor;
+
+/// Slashed cursor with complete value.
+/// ```
+/// use hamcrest::assert_that;
+/// use hamcrest::{equal_to, is, HamcrestMatcher};
+/// use server::handlers::cursor::Cursor;
+/// use server::handlers::sh_cursor::ShCursor;
+///
+/// let url = ShCursor::new(Cursor::new(String::from("http://localhost:3000")), String::from("repos")).as_string();
+/// assert_that!(url, is(equal_to(String::from("http://localhost:3000/repos"))));
+/// ```
+pub struct ShCursor {
+    origin: Cursor,
+    complete: String,
+}
+
+impl ShCursor {
+    /// New.
+    pub fn new(origin: Cursor, complete: String) -> ShCursor {
+        ShCursor { origin, complete }
+    }
+
+    /// Format as string.
+    pub fn as_string(self) -> String {
+        format!("{}/{}", self.origin.as_string(), self.complete)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::handlers::cursor::Cursor;
+    use crate::handlers::sh_cursor::ShCursor;
+    use anyhow::Result;
+    use hamcrest::{equal_to, is, HamcrestMatcher};
+
+    #[test]
+    fn prints_formatted() -> Result<()> {
+        let url = ShCursor::new(
+            Cursor {
+                base: String::from("http://localhost:3000"),
+            },
+            String::from("repos"),
+        )
+        .as_string();
+        assert_that!(
+            url,
+            is(equal_to(String::from("http://localhost:3000/repos")))
+        );
+        Ok(())
+    }
+}

--- a/server/src/objects/fakehub.rs
+++ b/server/src/objects/fakehub.rs
@@ -35,7 +35,7 @@ use uuid::Uuid;
 /// let fakehub = FakeHub::default();
 /// let github = fakehub.main();
 /// let jeff = github.user("jeff").expect("Failed to get user");
-/// assert_that!(&jeff.username, is(equal_to("jeff")));
+/// assert_that!(&jeff.login, is(equal_to("jeff")));
 /// ```
 #[derive(Clone)]
 pub struct FakeHub {
@@ -91,7 +91,7 @@ mod tests {
         let users = github.clone().users();
         let user = users.first().expect("Failed to get user");
         assert_that!(&github.name, is(equal_to("main")));
-        assert_that!(&user.username, is(equal_to("jeff")));
+        assert_that!(&user.login, is(equal_to("jeff")));
         Ok(())
     }
 }

--- a/server/src/objects/github.rs
+++ b/server/src/objects/github.rs
@@ -38,7 +38,7 @@ impl GitHub {
     /// Add user to GitHub.
     /// `user` User
     pub fn add_user(&mut self, user: User) {
-        self.users.insert(user.clone().username, user);
+        self.users.insert(user.clone().login, user);
     }
 
     /// User.
@@ -72,7 +72,7 @@ mod tests {
         github.add_user(User::new(expected.clone()));
         let users = github.users();
         let user = users.first().expect("Failed to get user");
-        assert_that!(&user.username, is(equal_to(&expected)));
+        assert_that!(&user.login, is(equal_to(&expected)));
         Ok(())
     }
 
@@ -86,7 +86,7 @@ mod tests {
         let expected = "foo";
         github.add_user(User::new(String::from(expected)));
         let foo = github.user(expected).expect("Failed to get user");
-        assert_that!(&foo.username, is(equal_to(expected)));
+        assert_that!(&foo.login, is(equal_to(expected)));
         Ok(())
     }
 }

--- a/server/src/objects/json/json_user.rs
+++ b/server/src/objects/json/json_user.rs
@@ -1,0 +1,70 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2024 Aliaksei Bialiauski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+use crate::objects::user::User;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// JSON User.
+#[derive(Serialize, Deserialize)]
+pub struct JsonUser {
+    origin: User,
+}
+
+impl JsonUser {
+    /// New.
+    pub fn new(origin: User) -> JsonUser {
+        JsonUser { origin }
+    }
+
+    /// Print it as JSON document.
+    pub fn as_json(self) -> Value {
+        let mut map = Map::new();
+        map.insert(String::from("login"), Value::from(self.origin.login));
+        for (k, v) in self.origin.extra.into_iter() {
+            map.insert(k, v);
+        }
+        Value::Object(map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::objects::json::json_user::JsonUser;
+    use crate::objects::user::User;
+    use anyhow::Result;
+    use hamcrest::{equal_to, is, HamcrestMatcher};
+    use serde_json::Value;
+
+    #[test]
+    fn prints_json() -> Result<()> {
+        let jeff = "jeff";
+        let mut base = User::new(String::from(jeff));
+        let url = "testing";
+        base.extra
+            .insert(String::from("url"), Value::String(String::from(url)));
+        let user = JsonUser::new(base);
+        let value = user.as_json();
+        assert_that!(value["login"].as_str(), is(equal_to(Some(jeff))));
+        assert_that!(value["url"].as_str(), is(equal_to(Some(url))));
+        Ok(())
+    }
+}

--- a/server/src/objects/json/mod.rs
+++ b/server/src/objects/json/mod.rs
@@ -19,14 +19,5 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-/// FakeHub.
-pub mod fakehub;
-/// GitHub.
-pub mod github;
-/// GitHub repository.
-pub mod repo;
-/// GitHub user.
-pub mod user;
-mod user_defaults;
-mod json;
-mod node_id;
+/// JSON User.
+pub mod json_user;

--- a/server/src/objects/mod.rs
+++ b/server/src/objects/mod.rs
@@ -23,9 +23,9 @@
 pub mod fakehub;
 /// GitHub.
 pub mod github;
+/// JSON objects.
+pub mod json;
 /// GitHub repository.
 pub mod repo;
 /// GitHub user.
 pub mod user;
-/// JSON objects.
-pub mod json;

--- a/server/src/objects/mod.rs
+++ b/server/src/objects/mod.rs
@@ -27,6 +27,5 @@ pub mod github;
 pub mod repo;
 /// GitHub user.
 pub mod user;
-mod user_defaults;
-mod json;
-mod node_id;
+/// JSON objects.
+pub mod json;

--- a/server/src/objects/user.rs
+++ b/server/src/objects/user.rs
@@ -19,19 +19,25 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+use crate::handlers::cursor::Cursor;
+use crate::handlers::sh_cursor::ShCursor;
 use crate::objects::github::GitHub;
 use crate::objects::repo::Repo;
 use anyhow::Result;
 use log::info;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Number, Value};
 
 /// GitHub user.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct User {
-    /// Username.
-    pub username: String,
+    /// Login, a.k.a. username.
+    pub login: String,
     /// Repos.
     pub repos: Vec<Repo>,
+    /// Extra information.
+    pub extra: Map<String, Value>,
 }
 
 impl User {
@@ -49,8 +55,9 @@ impl User {
     /// ```
     pub fn new(username: String) -> User {
         User {
-            username,
+            login: username,
             repos: vec![],
+            extra: Map::new(),
         }
     }
 
@@ -60,16 +67,175 @@ impl User {
     ///```
     /// use server::objects::fakehub::FakeHub;
     /// use server::objects::user::User;
+    ///
     /// let fakehub = FakeHub::default();
     /// let mut github = fakehub.main().clone();
     /// User::new(String::from("foo")).register_in(&mut github).expect("Failed to register user");
     ///```
-    pub fn register_in(&self, github: &mut GitHub) -> Result<(), String> {
-        match github.user(&self.username) {
-            Some(u) => Err(format!("User with login @{} already exists!", u.username)),
+    // @todo #137:30min Create NodeId object that will give MD5 hash.
+    //  Almost in any response, including user, we should display Node ID as
+    //  GitHub API does. Looks like they use MD5 for it. Let's do the same, but
+    //  we need only one that hash, because only one instance can be run. Let's
+    //  hash UTC datetime when server was bootstrapped.
+    // @todo #137:35min Pass port to the base cursor. Now we hardcode the
+    //  address localhost:3000, however we need to handle generic ports that
+    //  users can set.
+    pub fn register_in(&mut self, github: &mut GitHub) -> Result<(), String> {
+        match github.user(&self.login) {
+            Some(u) => Err(format!("User with login @{} already exists!", u.login)),
             None => {
+                let cursor = Cursor {
+                    base: String::from("localhost:3000"),
+                };
+                let id = rand::thread_rng().gen_range(0..100_000_000);
+                self.extra
+                    .insert(String::from("node_id"), Value::String(String::from("")));
+                self.extra
+                    .insert(String::from("id"), Value::Number(Number::from(id)));
+                self.extra.insert(
+                    String::from("avatar_url"),
+                    Value::String(format!("u/{}?v=4", id)),
+                );
+                self.extra
+                    .insert(String::from("gravatar_id"), Value::String(String::from("")));
+                self.extra.insert(
+                    String::from("url"),
+                    Value::String(
+                        ShCursor::new(cursor.clone(), format!("users/{}", self.login))
+                            .as_string(),
+                    ),
+                );
+                self.extra.insert(
+                    String::from("html_url"),
+                    Value::String(
+                        ShCursor::new(cursor.clone(), self.login.to_string()).as_string(),
+                    ),
+                );
+                self.extra.insert(
+                    String::from("followers_url"),
+                    Value::String(
+                        ShCursor::new(
+                            cursor.clone(),
+                            format!("users/{}/followers", self.login),
+                        )
+                        .as_string(),
+                    ),
+                );
+                let following = ShCursor::new(
+                    cursor.clone(),
+                    format!("users/{}/following", self.login),
+                )
+                .as_string();
+                self.extra.insert(
+                    String::from("following_url"),
+                    Value::String(format!(
+                        "[{}{{/other_user}}]({}%7B/other_user%7D)",
+                        following, following
+                    )),
+                );
+                let gists =
+                    ShCursor::new(cursor.clone(), format!("users/{}/gists", self.login))
+                        .as_string();
+                self.extra.insert(
+                    String::from("gists_url"),
+                    Value::String(format!(
+                        "[{}{{/gist_id}}]({}%7B/gist_id%7D)",
+                        gists, gists
+                    )),
+                );
+                let starred = ShCursor::new(
+                    cursor.clone(),
+                    format!("users/{}/starred", self.login),
+                )
+                .as_string();
+                self.extra.insert(
+                    String::from("starred_url"),
+                    Value::String(format!(
+                        "[{}{{/owner}}{{/repo}}]({}%7B/owner%7D%7B/repo%7D)",
+                        starred, starred
+                    )),
+                );
+                self.extra.insert(
+                    String::from("subscriptions_url"),
+                    Value::String(
+                        ShCursor::new(
+                            cursor.clone(),
+                            format!("users/{}/subscriptions", self.login),
+                        )
+                        .as_string(),
+                    ),
+                );
+                self.extra.insert(
+                    String::from("organizations_url"),
+                    Value::String(
+                        ShCursor::new(
+                            cursor.clone(),
+                            format!("users/{}/orgs", self.login),
+                        )
+                        .as_string(),
+                    ),
+                );
+                self.extra.insert(
+                    String::from("repos_url"),
+                    Value::String(
+                        ShCursor::new(
+                            cursor.clone(),
+                            format!("users/{}/repos", self.login),
+                        )
+                        .as_string(),
+                    ),
+                );
+                let events =
+                    ShCursor::new(cursor.clone(), format!("users/{}/events", self.login))
+                        .as_string();
+                self.extra.insert(
+                    String::from("events_url"),
+                    Value::String(format!(
+                        "[{}{{/privacy}}]({}%7B/privacy%7D)",
+                        events, events
+                    )),
+                );
+                self.extra.insert(
+                    String::from("received_events_url"),
+                    Value::String(
+                        ShCursor::new(
+                            cursor,
+                            format!("users/{}/received_events", self.login),
+                        )
+                        .as_string(),
+                    ),
+                );
+                self.extra
+                    .insert(String::from("type"), Value::String(String::from("User")));
+                self.extra
+                    .insert(String::from("site_admin"), Value::Bool(false));
+                self.extra.insert(
+                    String::from("name"),
+                    Value::String(String::from("FakeHub user")),
+                );
+                self.extra.insert(String::from("company"), Value::Null);
+                self.extra.insert(String::from("blog"), Value::Null);
+                self.extra.insert(String::from("location"), Value::Null);
+                self.extra.insert(String::from("email"), Value::Null);
+                self.extra.insert(String::from("hireable"), Value::Null);
+                self.extra.insert(String::from("bio"), Value::Null);
+                self.extra
+                    .insert(String::from("twitter_username"), Value::Null);
+                self.extra
+                    .insert(String::from("public_repos"), Value::Number(Number::from(0)));
+                self.extra
+                    .insert(String::from("public_gists"), Value::Number(Number::from(0)));
+                self.extra
+                    .insert(String::from("followers"), Value::Number(Number::from(0)));
+                self.extra
+                    .insert(String::from("following"), Value::Number(Number::from(0)));
+                let now = chrono::offset::Utc::now();
+                self.extra
+                    .insert(String::from("created_at"), Value::String(now.to_string()));
+                self.extra
+                    .insert(String::from("updated_at"), Value::String(now.to_string()));
                 github.add_user(self.clone());
-                info!("Registered @{}", self.username);
+                info!("Registered @{}", self.login);
                 Ok(())
             }
         }
@@ -87,7 +253,7 @@ mod tests {
     fn returns_username() -> Result<()> {
         let expected = "jeff";
         let jeff = User::new(String::from(expected));
-        assert_that!(jeff.username, is(equal_to(String::from(expected))));
+        assert_that!(jeff.login, is(equal_to(String::from(expected))));
         Ok(())
     }
 
@@ -100,7 +266,7 @@ mod tests {
             .register_in(&mut github)
             .expect("Failed to register user");
         let pulled = github.users.get(&foo).expect("Failed to get user");
-        assert_that!(pulled.clone().username, is(equal_to(foo)));
+        assert_that!(pulled.clone().login, is(equal_to(foo)));
         Ok(())
     }
 
@@ -112,5 +278,19 @@ mod tests {
         User::new(String::from("jeff"))
             .register_in(&mut github)
             .expect("Failed to register user");
+    }
+
+    #[test]
+    fn registers_with_extra() -> Result<()> {
+        let fakehub = FakeHub::default();
+        let mut github = fakehub.main();
+        User::new(String::from("foo"))
+            .register_in(&mut github)
+            .expect("Failed to register user");
+        let user = github.users.get("foo").expect("Failed to get user");
+        let url = user.extra.get("url").expect("Failed to read property");
+        assert_that!(url.as_str(), is(equal_to(Some("localhost:3000/users/foo"))));
+        assert_that!(user.extra.len(), is(equal_to(31)));
+        Ok(())
     }
 }


### PR DESCRIPTION
In this pull, I've introduced new field for `user.rs`: `extra`, and new `json_user.rs` that transforms `user.extra` into JSON extended format, as GitHub REST API does.

closes: #137
History:
- **feat(#137): json_user for extended users**
- **feat(#137): cursor**
- **feat(#137): user extra**
- **feat(#137): mod**
- **feat(#137): clean for cargo fmt**
- **feat(#137): now login**


<!-- start pr-codex -->

---

## PR-Codex overview
The PR adds JSON serialization for users, introduces cursor handling, and updates user login handling.

### Detailed summary
- Added JSON serialization for users
- Introduced cursor handling
- Updated user login handling

> The following files were skipped due to too many changes: `server/src/objects/user.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->