### PR TITLE
feat(#144): GET user

### DIFF
--- a/server/src/handlers/user.rs
+++ b/server/src/handlers/user.rs
@@ -24,26 +24,76 @@ use crate::objects::json::json_user::JsonUser;
 use crate::ServerConfig;
 use axum::extract::{Path, State};
 use axum::Json;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 
 /// User by login.
+// @todo #144:35min Test that 404 status code is thrown with "Not Found"
+//  response. For now we only check JSON response with: message,
+//  documentation_url, status nodes. Let's create unit test that will show that
+//  404 is the status code of response.
 pub async fn user(
     Path(params): Path<HashMap<String, String>>,
     State(config): State<ServerConfig>,
 ) -> Json<Value> {
     let login = params.get("login").expect("Failed to get login");
     let github = config.fakehub.main();
-    let user = github.user(login).expect("Failed to get user");
-    Json(JsonUser::new(user.clone()).as_json())
+    match github.user(login) {
+        Some(user) => Json(JsonUser::new(user.clone()).as_json()),
+        None => {
+            let mut response = Map::new();
+            response.insert(
+                String::from("message"),
+                Value::String(String::from("Not Found")),
+            );
+            response.insert(
+                String::from("documentation_url"),
+                Value::String(String::from("https://github.com/h1alexbel/fakehub")),
+            );
+            response.insert(String::from("status"), Value::String(String::from("404")));
+            Json(Value::Object(response))
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::handlers::user::user;
+    use crate::objects::fakehub::FakeHub;
+    use crate::ServerConfig;
     use anyhow::Result;
+    use axum::extract::{Path, State};
+    use hamcrest::{equal_to, is, HamcrestMatcher};
+    use std::collections::HashMap;
 
-    #[test]
-    fn returns_user() -> Result<()> {
+    #[tokio::test]
+    async fn returns_user() -> Result<()> {
+        let fakehub = FakeHub::default();
+        let state = State(ServerConfig { fakehub });
+        let mut params = HashMap::new();
+        let expected = "jeff";
+        params.insert(String::from("login"), String::from(expected));
+        let user = user(Path(params), state).await;
+        assert_that!(user["login"].as_str(), is(equal_to(Some(expected))));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn returns_not_found() -> Result<()> {
+        let fakehub = FakeHub::default();
+        let state = State(ServerConfig { fakehub });
+        let mut params = HashMap::new();
+        params.insert(String::from("login"), String::from("unknown"));
+        let response = user(Path(params), state).await;
+        assert_that!(
+            response["message"].as_str(),
+            is(equal_to(Some("Not Found")))
+        );
+        assert_that!(
+            response["documentation_url"].as_str(),
+            is(equal_to(Some("https://github.com/h1alexbel/fakehub")))
+        );
+        assert_that!(response["status"].as_str(), is(equal_to(Some("404"))));
         Ok(())
     }
 }

--- a/server/src/handlers/user.rs
+++ b/server/src/handlers/user.rs
@@ -19,17 +19,31 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-/// Coordinates.
-pub mod coordinates;
-/// Cursor.
-pub mod cursor;
-/// Home handler.
-pub mod home;
-/// Node ID.
-pub mod node_id;
-/// Handler for internal user registration.
-pub mod register_user;
-/// Slashed Cursor.
-pub mod sh_cursor;
-/// User.
-pub mod user;
+
+use crate::objects::json::json_user::JsonUser;
+use crate::ServerConfig;
+use axum::extract::{Path, State};
+use axum::Json;
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// User by login.
+pub async fn user(
+    Path(params): Path<HashMap<String, String>>,
+    State(config): State<ServerConfig>,
+) -> Json<Value> {
+    let login = params.get("login").expect("Failed to get login");
+    let github = config.fakehub.main();
+    let user = github.user(login).expect("Failed to get user");
+    Json(JsonUser::new(user.clone()).as_json())
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    #[test]
+    fn returns_user() -> Result<()> {
+        Ok(())
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -31,6 +31,7 @@ use tokio::net::TcpListener;
 
 use crate::handlers::home;
 use crate::handlers::register_user::register_user;
+use crate::handlers::user::user;
 use crate::objects::fakehub::FakeHub;
 
 /// Handlers.
@@ -89,6 +90,7 @@ impl Server {
                 Router::new()
                     .route("/", get(home::home))
                     .route("/users", post(register_user))
+                    .route("/users/:login", get(user))
                     .with_state(ServerConfig {
                         fakehub: FakeHub::with_addr(addr),
                     }),

--- a/server/src/objects/fakehub.rs
+++ b/server/src/objects/fakehub.rs
@@ -60,7 +60,6 @@ impl Default for FakeHub {
 }
 
 /// Create GitHub.
-// generate jeff
 fn create_github() -> GitHub {
     let mut users: HashMap<String, User> = HashMap::new();
     let jeff = String::from("jeff");

--- a/server/src/objects/fakehub.rs
+++ b/server/src/objects/fakehub.rs
@@ -60,6 +60,7 @@ impl Default for FakeHub {
 }
 
 /// Create GitHub.
+// generate jeff
 fn create_github() -> GitHub {
     let mut users: HashMap<String, User> = HashMap::new();
     let jeff = String::from("jeff");


### PR DESCRIPTION
In this pull, I've introduced `user` handler for `/users/:login`, as mock version of respective endpoint in GitHub REST API.

closes #144
History:
- **feat(#144): /user/:login**
- **feat(#144): user()**
- **feat(#144): no jeff**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `user` module with a `user` handler function that returns user data or a 404 response based on login. It includes unit tests for the handler function.

### Detailed summary
- Added `user` module with `user` handler function
- Handler returns user data or 404 response
- Included unit tests for the handler function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->