### PR TITLE
feat(#147): GET /users

### DIFF
--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -31,5 +31,7 @@ pub mod node_id;
 pub mod register_user;
 /// Slashed Cursor.
 pub mod sh_cursor;
-/// User.
+/// GitHub user by login.
 pub mod user;
+/// All GitHub users.
+pub mod users;

--- a/server/src/handlers/users.rs
+++ b/server/src/handlers/users.rs
@@ -46,6 +46,7 @@ mod tests {
     use crate::ServerConfig;
     use anyhow::Result;
     use axum::extract::State;
+    use hamcrest::{equal_to, is, HamcrestMatcher};
 
     #[tokio::test]
     #[allow(clippy::question_mark_used)]
@@ -54,8 +55,9 @@ mod tests {
             fakehub: FakeHub::default(),
         }))
         .await;
-        let print = users.0;
-        println!("{}", serde_json::to_string_pretty(&print)?);
+        let user = users.first().expect("Failed to get first JSON user");
+        assert_that!(user["id"].as_u64(), is(equal_to(Some(1))));
+        assert_that!(user["login"].as_str(), is(equal_to(Some("jeff"))));
         Ok(())
     }
 }

--- a/server/src/handlers/users.rs
+++ b/server/src/handlers/users.rs
@@ -56,6 +56,7 @@ mod tests {
         }))
         .await;
         let user = users.first().expect("Failed to get first JSON user");
+        assert_that!(users.len(), is(equal_to(2)));
         assert_that!(user["id"].as_u64(), is(equal_to(Some(1))));
         assert_that!(user["login"].as_str(), is(equal_to(Some("jeff"))));
         Ok(())

--- a/server/src/handlers/users.rs
+++ b/server/src/handlers/users.rs
@@ -1,0 +1,40 @@
+use crate::objects::json::json_user::JsonUser;
+use crate::ServerConfig;
+use axum::extract::State;
+use axum::Json;
+use serde_json::Value;
+
+/// All GitHub users, ordered by their id.
+/// See: <a href="https://api.github.com/users">GitHub implementation</a>.
+pub async fn users(State(config): State<ServerConfig>) -> Json<Vec<Value>> {
+    let fakehub = config.fakehub;
+    let github = fakehub.main();
+    Json(
+        github
+            .users()
+            .iter()
+            .map(|u| JsonUser::new(u.clone()).as_json())
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::handlers::users::users;
+    use crate::objects::fakehub::FakeHub;
+    use crate::ServerConfig;
+    use anyhow::Result;
+    use axum::extract::State;
+
+    #[tokio::test]
+    #[allow(clippy::question_mark_used)]
+    async fn returns_users() -> Result<()> {
+        let users = users(State(ServerConfig {
+            fakehub: FakeHub::default(),
+        }))
+        .await;
+        let print = users.0;
+        println!("{}", serde_json::to_string_pretty(&print)?);
+        Ok(())
+    }
+}

--- a/server/src/handlers/users.rs
+++ b/server/src/handlers/users.rs
@@ -1,3 +1,24 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2024 Aliaksei Bialiauski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 use crate::objects::json::json_user::JsonUser;
 use crate::ServerConfig;
 use axum::extract::State;
@@ -9,13 +30,13 @@ use serde_json::Value;
 pub async fn users(State(config): State<ServerConfig>) -> Json<Vec<Value>> {
     let fakehub = config.fakehub;
     let github = fakehub.main();
-    Json(
-        github
-            .users()
-            .iter()
-            .map(|u| JsonUser::new(u.clone()).as_json())
-            .collect(),
-    )
+    let mut users: Vec<Value> = github
+        .users()
+        .iter()
+        .map(|u| JsonUser::new(u.clone()).as_json())
+        .collect();
+    users.sort_by_key(|user| user.get("id").and_then(|id| id.as_u64()));
+    Json(users)
 }
 
 #[cfg(test)]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -32,6 +32,7 @@ use tokio::net::TcpListener;
 use crate::handlers::home;
 use crate::handlers::register_user::register_user;
 use crate::handlers::user::user;
+use crate::handlers::users::users;
 use crate::objects::fakehub::FakeHub;
 
 /// Handlers.
@@ -91,6 +92,7 @@ impl Server {
                     .route("/", get(home::home))
                     .route("/users", post(register_user))
                     .route("/users/:login", get(user))
+                    .route("/users", get(users))
                     .with_state(ServerConfig {
                         fakehub: FakeHub::with_addr(addr),
                     }),

--- a/server/src/objects/fakehub.rs
+++ b/server/src/objects/fakehub.rs
@@ -67,6 +67,11 @@ fn create_github() -> GitHub {
     let mut jeff = User::new(name.clone());
     jeff.extra
         .insert(String::from("id"), Value::Number(Number::from(1)));
+    let mut second = User::new(String::from("h1alexbel"));
+    second
+        .extra
+        .insert(String::from("id"), Value::Number(Number::from(2)));
+    users.insert(String::from("h1alexbel"), second);
     users.insert(name, jeff);
     GitHub {
         id: Uuid::new_v4(),
@@ -134,9 +139,8 @@ mod tests {
         let fakehub = FakeHub::default();
         let github = fakehub.main();
         let users = github.clone().users();
-        let user = users.first().expect("Failed to get user");
         assert_that!(&github.name, is(equal_to("main")));
-        assert_that!(&user.login, is(equal_to("jeff")));
+        assert_that!(users.len(), is(equal_to(2)));
         Ok(())
     }
 

--- a/server/src/objects/fakehub.rs
+++ b/server/src/objects/fakehub.rs
@@ -23,6 +23,7 @@ use crate::handlers::node_id::NodeId;
 use crate::objects::github::GitHub;
 use crate::objects::user::User;
 use chrono::{DateTime, Utc};
+use serde_json::{Number, Value};
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -62,8 +63,11 @@ impl Default for FakeHub {
 /// Create GitHub.
 fn create_github() -> GitHub {
     let mut users: HashMap<String, User> = HashMap::new();
-    let jeff = String::from("jeff");
-    users.insert(jeff.clone(), User::new(jeff));
+    let name = String::from("jeff");
+    let mut jeff = User::new(name.clone());
+    jeff.extra
+        .insert(String::from("id"), Value::Number(Number::from(1)));
+    users.insert(name, jeff);
     GitHub {
         id: Uuid::new_v4(),
         name: String::from("main"),


### PR DESCRIPTION
In this pull, I've implemented mock version of https://api.github.com/users endpoint.

closes: #147
History:
- **feat(#147): json<vec<value>>**
- **feat(#147): sort_by_key**
- **feat(#147): jeff comes first**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the server to include a new `users` module and endpoint, allowing retrieval of all GitHub users.

### Detailed summary
- Added `users` module to handle all GitHub users.
- Updated `FakeHub` to include multiple users with additional data.
- Implemented endpoint to retrieve and sort all users by id.
- Added tests for the new `users` endpoint functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->