### PR TITLE
feat(#129): -d for detached run

### DIFF
--- a/.github/workflows/just.yml
+++ b/.github/workflows/just.yml
@@ -44,11 +44,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install @openapitools/openapi-generator-cli@2.13.7 -g
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/just.yml
+++ b/.github/workflows/just.yml
@@ -49,6 +49,11 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - uses: extractions/setup-just@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install @openapitools/openapi-generator-cli@2.13.7 -g
         with:
           just-version: ${{ matrix.just-version }}
         name: Install toolchain

--- a/.github/workflows/just.yml
+++ b/.github/workflows/just.yml
@@ -44,16 +44,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
-      - uses: extractions/setup-just@v2
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm install @openapitools/openapi-generator-cli@2.13.7 -g
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+      - uses: extractions/setup-just@v2
         with:
           just-version: ${{ matrix.just-version }}
         name: Install toolchain

--- a/README.md
+++ b/README.md
@@ -97,12 +97,13 @@ TBD..
 
 You can use the following options within `fakehub` command-line tool:
 
-| Name            | Value   | Default | Description                                                                                               |
-|-----------------|---------|---------|-----------------------------------------------------------------------------------------------------------|
-| `port`          | int     | `3000`  | Port to run fakehub server on.                                                                            |
-| `v`             | boolean | `false` | Verbose run output, i.e. debug logs, etc.                                                                 |
-| `report`        | boolean | `false` | Generate report after fakehub shutdown.                                                                   |
-| `report-format` | string  | -       | Generated report format. Possible values: `latex` for [LaTeX], `xml` for [XML], and `txt` for plain text. |
+| Name              | Value   | Default | Description                                                                                               |
+|-------------------|---------|---------|-----------------------------------------------------------------------------------------------------------|
+| `-p`, `--port`    | int     | `3000`  | Port to run fakehub server on.                                                                            |
+| `-v`, `--verbose` | boolean | `false` | Verbose run output, i.e. debug logs, etc.                                                                 |
+| `-d`,  `--detach` | boolean | `false` | Run fakehub server in detached mode.                                                                      |
+| `report`          | boolean | `false` | Generate report after fakehub shutdown.                                                                   |
+| `report-format`   | string  | -       | Generated report format. Possible values: `latex` for [LaTeX], `xml` for [XML], and `txt` for plain text. |
 
 ## How to contribute?
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -45,6 +45,7 @@ tokio = { version = "1.0.0", features = ["rt", "rt-multi-thread", "macros"] }
 log = "0.4.21"
 tracing-subscriber = "0.3.18"
 tracing = "0.1.40"
+reqwest = "0.12.7"
 
 [features]
 default = ["cli"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -46,6 +46,7 @@ log = "0.4.21"
 tracing-subscriber = "0.3.18"
 tracing = "0.1.40"
 reqwest = "0.12.7"
+defer = "0.2.1"
 
 [features]
 default = ["cli"]

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -50,4 +50,7 @@ pub(crate) struct StartArgs {
     /// Verbose output.
     #[arg(short, long, default_value = "false")]
     pub(crate) verbose: bool,
+    /// Run in detach mode.
+    #[arg(short, long, default_value = "false")]
+    pub(crate) detach: bool,
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,8 +28,14 @@ use log::info;
 use server::Server;
 
 use crate::args::{Args, Command};
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
 
 mod args;
+
+#[cfg_attr(target_os = "macos", allow(dead_code))]
+#[cfg_attr(target_os = "linux", allow(dead_code))]
+const DETACHED_FLAG_CODE: i32 = 0x00000008;
 
 #[tokio::main]
 async fn main() {
@@ -59,9 +65,7 @@ async fn main() {
                             command.arg("--verbose");
                         }
                         #[cfg(target_os = "windows")]
-                        use std::os::windows::process::CommandExt;
-                        #[cfg(target_os = "windows")]
-                        command.creation_flags(0x00000008);
+                        command.creation_flags(DETACHED_FLAG_CODE);
                         match command.spawn() {
                             Ok(_) => println!(
                                 "Server is running in detached mode on port {}",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -61,6 +61,7 @@ async fn main() {
                             command.arg("--verbose");
                         }
                         #[cfg(target_os = "windows")]
+                        /// Detached windows process flag.
                         command.creation_flags(0x00000008);
                         match command.spawn() {
                             Ok(_) => println!(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,10 +33,6 @@ use std::os::windows::process::CommandExt;
 
 mod args;
 
-#[cfg_attr(target_os = "macos", allow(dead_code))]
-#[cfg_attr(target_os = "linux", allow(dead_code))]
-const DETACHED_FLAG_CODE: i32 = 0x00000008;
-
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
@@ -65,7 +61,7 @@ async fn main() {
                             command.arg("--verbose");
                         }
                         #[cfg(target_os = "windows")]
-                        command.creation_flags(DETACHED_FLAG_CODE);
+                        command.creation_flags(0x00000008);
                         match command.spawn() {
                             Ok(_) => println!(
                                 "Server is running in detached mode on port {}",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -61,7 +61,7 @@ async fn main() {
                             command.arg("--verbose");
                         }
                         #[cfg(target_os = "windows")]
-                        /// Detached windows process flag.
+                        // Detached windows process flag.
                         command.creation_flags(0x00000008);
                         match command.spawn() {
                             Ok(_) => println!(

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -61,6 +61,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn runs_in_detached_mode() -> Result<()> {
         let mut command = std::process::Command::new("cli");
         command.arg("start").arg("-d");

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -24,10 +24,10 @@
 mod tests {
     use anyhow::Result;
     use assert_cmd::Command;
+    use defer::defer;
     use std::str;
     #[cfg_attr(target_os = "windows", allow(unused_imports))]
     use std::time::Duration;
-    use defer::defer;
 
     #[test]
     fn outputs_help() -> Result<()> {
@@ -75,12 +75,7 @@ mod tests {
     //  Now we have test for linux and macos. However, we need to maintain
     //  similar test case for windows as well.
     async fn accepts_request_in_detached_mode() -> Result<()> {
-        let _kill = defer(
-            ||
-            {
-                kill(3000)
-            }
-        );
+        let _kill = defer(|| kill(3000));
         let assertion = Command::cargo_bin("cli")?.arg("start").arg("-d").assert();
         let bytes = assertion.get_output().stdout.as_slice();
         let output = str::from_utf8(bytes)?;
@@ -106,7 +101,7 @@ mod tests {
         assert_eq!(status.expect("Failed to retrieve status"), 200);
         Ok(())
     }
-    
+
     #[cfg_attr(target_os = "windows", allow(dead_code))]
     fn kill(port: usize) {
         std::process::Command::new("sh")

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -25,6 +25,7 @@ mod tests {
     use anyhow::Result;
     use assert_cmd::Command;
     use std::str;
+    #[cfg_attr(target_os = "windows", allow(unused_imports))]
     use std::time::Duration;
 
     #[test]

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -48,11 +48,15 @@ mod tests {
             .assert();
         let bytes = assertion.get_output().stdout.as_slice();
         let output = str::from_utf8(bytes)?;
+        assert!(output.contains("-p"));
         assert!(output.contains("--port"));
         assert!(output.contains("The port to run [default: 3000]"));
-        assert!(output.contains("--verbose"));
         assert!(output.contains("-v"));
+        assert!(output.contains("--verbose"));
         assert!(output.contains("Verbose output"));
+        assert!(output.contains("-d"));
+        assert!(output.contains("--detach"));
+        assert!(output.contains("Run in detach mode"));
         Ok(())
     }
 

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -60,6 +60,13 @@ mod tests {
         Ok(())
     }
 
+    // @todo #129:35min Find a way to run slow tests separately from fast tests.
+    //  This test `accepts_request_in_detached_mode` runs a way longer than
+    //  other unit tests. Let's mark such long tests as slow and run them
+    //  separately from fast test. Locally, developers will run only fast
+    //  tests, while CI server will run both. Check
+    //  <a href="https://www.yegor256.com/2023/08/22/fast-vs-deep-testing.html">this link<a>
+    //  for more information about this idea.
     #[tokio::test]
     #[cfg(not(target_os = "windows"))]
     // @todo #129:60min Create similar integration test for windows platform.

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -24,8 +24,8 @@
 mod tests {
     use anyhow::Result;
     use assert_cmd::Command;
-    use std::time::Duration;
     use std::str;
+    use std::time::Duration;
 
     #[test]
     fn outputs_help() -> Result<()> {

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -25,7 +25,7 @@ mod tests {
     use anyhow::Result;
     use assert_cmd::Command;
     use std::time::Duration;
-    use std::{str, thread};
+    use std::str;
 
     #[test]
     fn outputs_help() -> Result<()> {
@@ -103,7 +103,7 @@ mod tests {
     fn kill(port: usize) {
         std::process::Command::new("sh")
             .arg("-c")
-            .arg("killport 3000")
+            .arg(format!("killport {}", port))
             .output()
             .unwrap_or_else(|_| panic!("Failed to kill process on port {}", port));
     }

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -22,10 +22,11 @@
 #[allow(clippy::question_mark_used)]
 #[cfg(test)]
 mod tests {
-    use std::str;
-
     use anyhow::Result;
     use assert_cmd::Command;
+    use std::time::Duration;
+    use std::{str, thread};
+
     #[test]
     fn outputs_help() -> Result<()> {
         let assertion = Command::cargo_bin("cli")?.arg("--help").assert();
@@ -50,7 +51,20 @@ mod tests {
         assert!(output.contains("--port"));
         assert!(output.contains("The port to run [default: 3000]"));
         assert!(output.contains("--verbose"));
+        assert!(output.contains("-v"));
         assert!(output.contains("Verbose output"));
+        Ok(())
+    }
+
+    #[test]
+    fn runs_in_detached_mode() -> Result<()> {
+        let mut command = std::process::Command::new("cli");
+        command.arg("start").arg("-d");
+        let child = command
+            .spawn()
+            .expect("Failed to start the detached process");
+        thread::sleep(Duration::from_secs(1));
+        assert!(child.id() > 0, "Detached process did not start correctly.");
         Ok(())
     }
 

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -24,6 +24,7 @@
 mod tests {
     use anyhow::Result;
     use assert_cmd::Command;
+    #[cfg_attr(target_os = "windows", allow(unused_imports))]
     use defer::defer;
     use std::str;
     #[cfg_attr(target_os = "windows", allow(unused_imports))]

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -100,6 +100,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg_attr(target_os = "windows", allow(dead_code))]
     fn kill(port: usize) {
         std::process::Command::new("sh")
             .arg("-c")

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -27,6 +27,7 @@ mod tests {
     use std::str;
     #[cfg_attr(target_os = "windows", allow(unused_imports))]
     use std::time::Duration;
+    use defer::defer;
 
     #[test]
     fn outputs_help() -> Result<()> {
@@ -74,6 +75,12 @@ mod tests {
     //  Now we have test for linux and macos. However, we need to maintain
     //  similar test case for windows as well.
     async fn accepts_request_in_detached_mode() -> Result<()> {
+        let _kill = defer(
+            ||
+            {
+                kill(3000)
+            }
+        );
         let assertion = Command::cargo_bin("cli")?.arg("start").arg("-d").assert();
         let bytes = assertion.get_output().stdout.as_slice();
         let output = str::from_utf8(bytes)?;
@@ -97,10 +104,9 @@ mod tests {
             }
         }
         assert_eq!(status.expect("Failed to retrieve status"), 200);
-        kill(3000);
         Ok(())
     }
-
+    
     #[cfg_attr(target_os = "windows", allow(dead_code))]
     fn kill(port: usize) {
         std::process::Command::new("sh")

--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ gen:
   node --version
   npm --version
   cd github-mirror && \
-   npm install @openapitools/openapi-generator-cli -g && \
+   npm install @openapitools/openapi-generator-cli@2.13.7 -g && \
     openapi-generator-cli generate -i github.yml -g rust -o .
 
 # Build the project.

--- a/justfile
+++ b/justfile
@@ -23,6 +23,7 @@
 # Install required tools
 install:
   cargo install cargo-machete
+  cargo install killport
 
 # Full build.
 full:

--- a/justfile
+++ b/justfile
@@ -32,6 +32,7 @@ full:
 
 # Generate code.
 gen:
+  node --version
   npm --version
   cd github-mirror && \
    npm install @openapitools/openapi-generator-cli -g && \


### PR DESCRIPTION
In this pull, I've introduced `-d` option for server detached run.

closes #129 
History:
- **feat(#129): -v, test setup**
- **feat(#129): -d**
- **feat(#129): --detach arg**
- **feat(#129): ignore for now**
- **feat(#129): match**
- **feat(#129): accepts_request_in_detached_mode**
- **feat(#129): killport**
- **feat(#129): puzzle for deep testing**
- **feat(#129): imports**
- **feat(#129): clean for check**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `reqwest` and `defer` dependencies, introduces a `detach` mode in `args.rs`, and implements detached mode functionality in `main.rs` for the CLI tool. 

### Detailed summary
- Added `reqwest` and `defer` dependencies
- Introduced `detach` mode in `args.rs`
- Implemented detached mode functionality in `main.rs` for the CLI tool

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->