### PR TITLE
feat(#166): --dry-run before upload to crates

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -55,6 +55,10 @@ release:
     git commit -am "${tag}"
     ls -a ../
     mkdir -p ~/.cargo && cp ../credentials ~/.cargo
+    cargo --color=never publish -p github-mirror --dry-run
+    cargo --color=never publish -p fakehub-server --features "mirror_release" --dry-run
+    cargo --color=never publish -p fakehub --dry-run
+    echo "Packages ready for upload to crates.io"
     cargo --color=never publish -p github-mirror
     cargo --color=never publish -p fakehub-server --features "mirror_release"
     cargo --color=never publish -p fakehub


### PR DESCRIPTION
closes #166 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `.rultor.yml` file to include dry-run commands for publishing several Rust packages to `crates.io`, ensuring that the packages are ready for upload without actually publishing them.

### Detailed summary
- Added dry-run commands for publishing:
  - `github-mirror`
  - `fakehub-server` with feature `mirror_release`
  - `fakehub`
- Included an echo statement to confirm packages are ready for upload.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->