### PR TITLE
feat(#174): arc github lock

### DIFF
--- a/server/src/handlers/coordinates.rs
+++ b/server/src/handlers/coordinates.rs
@@ -24,14 +24,14 @@ use regex::Regex;
 
 /// Coordinates.
 #[derive(Clone)]
-pub struct Coordinates {
-    fakehub: FakeHub,
+pub struct Coordinates<'a> {
+    fakehub: &'a FakeHub,
     regex: Regex,
 }
 
-impl Coordinates {
+impl<'a> Coordinates<'a> {
     /// New.
-    pub fn new(fakehub: FakeHub) -> Coordinates {
+    pub fn new(fakehub: &'a FakeHub) -> Coordinates<'a> {
         Coordinates {
             fakehub,
             regex: Regex::new(r"([^;]+);node:([a-f0-9]+)")
@@ -40,7 +40,7 @@ impl Coordinates {
     }
 
     /// Address.
-    pub fn address(self) -> String {
+    pub fn address(&self) -> String {
         let coords = self.fakehub.coords();
         let captures = self
             .regex
@@ -50,7 +50,7 @@ impl Coordinates {
     }
 
     /// Node ID.
-    pub fn node_id(self) -> String {
+    pub fn node_id(&self) -> String {
         let coords = self.fakehub.coords();
         let captures = self
             .regex
@@ -71,7 +71,7 @@ mod tests {
     #[test]
     fn returns_default_address() -> Result<()> {
         let fakehub = FakeHub::new(Utc.with_ymd_and_hms(2024, 9, 1, 9, 10, 11).unwrap());
-        let coordinates = Coordinates::new(fakehub);
+        let coordinates = Coordinates::new(&fakehub);
         let address = coordinates.address();
         assert_that!(address, is(equal_to(String::from("localhost"))));
         Ok(())
@@ -81,7 +81,7 @@ mod tests {
     fn returns_bind_address() -> Result<()> {
         let expected = String::from("localhost:1234");
         let fakehub = FakeHub::with_addr(expected.clone());
-        let coordinates = Coordinates::new(fakehub);
+        let coordinates = Coordinates::new(&fakehub);
         let address = coordinates.address();
         assert_that!(address, is(equal_to(expected)));
         Ok(())
@@ -91,7 +91,7 @@ mod tests {
     #[allow(clippy::unwrap_used)]
     fn returns_node_id() -> Result<()> {
         let fakehub = FakeHub::new(Utc.with_ymd_and_hms(2024, 9, 1, 9, 10, 11).unwrap());
-        let coordinates = Coordinates::new(fakehub);
+        let coordinates = Coordinates::new(&fakehub);
         let id = coordinates.node_id();
         assert_that!(
             id,

--- a/server/src/handlers/home.rs
+++ b/server/src/handlers/home.rs
@@ -37,7 +37,7 @@ use openapi::models::MetaRoot200Response;
 
 /// Home handler.
 pub async fn home(State(config): State<ServerConfig>) -> impl IntoResponse {
-    let address = Coordinates::new(config.fakehub).address();
+    let address = Coordinates::new(&config.fakehub).address();
     let response = Json(
         MetaRoot200Response::new(
             format!("{}/user", address),

--- a/server/src/handlers/register_user.rs
+++ b/server/src/handlers/register_user.rs
@@ -32,16 +32,16 @@ use log::info;
 ///
 /// * `payload`: JSON payload
 pub async fn register_user(
-    State(mut config): State<ServerConfig>,
+    State(config): State<ServerConfig>,
     Json(payload): Json<User>,
 ) -> Result<StatusCode, String> {
     let mut newcomer = User::new(payload.login.clone());
     let fakehub = &config.fakehub;
-    let mut github = fakehub.main();
+    let github = fakehub.main();
     let mut github = github
         .lock()
         .map_err(|e| format!("Mutex lock failed: {}", e))
-        .expect("Failed to lock GitHub");
+        .expect("Failed to get GitHub");
     match newcomer.register_in(&mut github, fakehub) {
         Ok(_) => {
             info!("New user is here. Hello @{}", newcomer.login);

--- a/server/src/handlers/register_user.rs
+++ b/server/src/handlers/register_user.rs
@@ -55,7 +55,6 @@ pub async fn register_user(
 mod tests {
     use crate::handlers::register_user::register_user;
     use crate::objects::fakehub::FakeHub;
-    use crate::objects::json::json_user::JsonUser;
     use crate::objects::user::User;
     use crate::ServerConfig;
     use anyhow::Result;

--- a/server/src/handlers/register_user.rs
+++ b/server/src/handlers/register_user.rs
@@ -67,10 +67,18 @@ mod tests {
         let server = ServerConfig {
             fakehub: FakeHub::default(),
         };
-        let state = State(server);
-        let status = register_user(state, Json::from(User::new(String::from("new1234"))))
+        let state = State(server.clone());
+        let registration = "new1234";
+        let status = register_user(state, Json::from(User::new(String::from(registration))))
             .await
             .expect("Failed to register user");
+        let fakehub = server.fakehub;
+        let github = fakehub.main();
+        let locked = github.lock().expect("Failed to lock GitHub");
+        let users = locked.clone().users();
+        let created =  locked.user(registration).expect("Failed to get user");
+        assert_that!(created.login.as_str(), is(equal_to(registration)));
+        assert_that!(users.len(), is(equal_to(3)));
         assert_that!(status.as_u16(), is(equal_to(201)));
         Ok(())
     }

--- a/server/src/handlers/user.rs
+++ b/server/src/handlers/user.rs
@@ -38,7 +38,9 @@ pub async fn user(
 ) -> Json<Value> {
     let login = params.get("login").expect("Failed to get login");
     let github = config.fakehub.main();
-    match github.user(login) {
+    let clone = github.clone();
+    let lock = clone.lock().expect("Failed to lock");
+    match lock.user(login) {
         Some(user) => Json(JsonUser::new(user.clone()).as_json()),
         None => {
             let mut response = Map::new();

--- a/server/src/handlers/users.rs
+++ b/server/src/handlers/users.rs
@@ -30,8 +30,10 @@ use serde_json::Value;
 pub async fn users(State(config): State<ServerConfig>) -> Json<Vec<Value>> {
     let fakehub = config.fakehub;
     let github = fakehub.main();
-    let mut users: Vec<Value> = github
+    let mut users: Vec<Value> = github.clone()
+        .lock().expect("Failed to lock").clone()
         .users()
+        // .users()
         .iter()
         .map(|u| JsonUser::new(u.clone()).as_json())
         .collect();

--- a/server/src/handlers/users.rs
+++ b/server/src/handlers/users.rs
@@ -30,10 +30,11 @@ use serde_json::Value;
 pub async fn users(State(config): State<ServerConfig>) -> Json<Vec<Value>> {
     let fakehub = config.fakehub;
     let github = fakehub.main();
-    let mut users: Vec<Value> = github.clone()
-        .lock().expect("Failed to lock").clone()
+    let mut users: Vec<Value> = github
+        .lock()
+        .expect("Failed to lock")
+        .clone()
         .users()
-        // .users()
         .iter()
         .map(|u| JsonUser::new(u.clone()).as_json())
         .collect();

--- a/server/src/objects/fakehub.rs
+++ b/server/src/objects/fakehub.rs
@@ -19,7 +19,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-use std::cell::{RefCell, RefMut};
 use crate::handlers::node_id::NodeId;
 use crate::objects::github::GitHub;
 use crate::objects::user::User;
@@ -39,8 +38,9 @@ use uuid::Uuid;
 ///
 /// let mut fakehub = FakeHub::default();
 /// let github = fakehub.main();
-/// // let jeff = github.user("jeff").expect("Failed to get user");
-/// // assert_that!(&jeff.login, is(equal_to("jeff")));
+/// let locked = github.lock().expect("Failed to lock GitHub");
+/// let jeff = locked.user("jeff").expect("Failed to get user");
+/// assert_that!(&jeff.login, is(equal_to("jeff")));
 /// ```
 #[derive(Clone)]
 pub struct FakeHub {
@@ -130,19 +130,21 @@ mod tests {
 
     #[test]
     fn returns_default_fakehub_instance() -> Result<()> {
-        let mut fakehub = FakeHub::default();
-        let default = fakehub.main();
-        // assert_that!(default.id.is_nil(), is(equal_to(false)));
+        let fakehub = FakeHub::default();
+        let github = fakehub.main();
+        let locked = github.lock().expect("Failed to lock");
+        assert_that!(locked.id.is_nil(), is(equal_to(false)));
         Ok(())
     }
 
     #[test]
     fn returns_default_github() -> Result<()> {
-        let mut fakehub = FakeHub::default();
+        let fakehub = FakeHub::default();
         let github = fakehub.main();
-        // let users = github.clone().users();
-        // assert_that!(&github.name, is(equal_to("main")));
-        // assert_that!(users.len(), is(equal_to(2)));
+        let locked = github.lock().expect("Failed to lock"); 
+        let users = locked.clone().users();
+        assert_that!(&locked.name, is(equal_to("main")));
+        assert_that!(users.len(), is(equal_to(2)));
         Ok(())
     }
 

--- a/server/src/objects/fakehub.rs
+++ b/server/src/objects/fakehub.rs
@@ -141,7 +141,7 @@ mod tests {
     fn returns_default_github() -> Result<()> {
         let fakehub = FakeHub::default();
         let github = fakehub.main();
-        let locked = github.lock().expect("Failed to lock"); 
+        let locked = github.lock().expect("Failed to lock");
         let users = locked.clone().users();
         assert_that!(&locked.name, is(equal_to("main")));
         assert_that!(users.len(), is(equal_to(2)));

--- a/server/src/objects/repo.rs
+++ b/server/src/objects/repo.rs
@@ -65,13 +65,13 @@ mod tests {
     fn creates_repo() -> Result<()> {
         let fakehub = FakeHub::default();
         let github = fakehub.main();
-        let mut jeff = github.user("jeff").expect("Failed to get user").clone();
-        let foo = String::from("foo");
-        Repo::new(foo.clone(), false).create_for(&mut jeff);
-        assert_that!(jeff.repos.len(), is(equal_to(1)));
-        let repos = jeff.repos;
-        let repo = repos.first().expect("Failed to get repo");
-        assert_that!(repo.clone().name, is(equal_to(foo)));
+        // let mut jeff = github.user("jeff").expect("Failed to get user").clone();
+        // let foo = String::from("foo");
+        // Repo::new(foo.clone(), false).create_for(&mut jeff);
+        // assert_that!(jeff.repos.len(), is(equal_to(1)));
+        // let repos = jeff.repos;
+        // let repo = repos.first().expect("Failed to get repo");
+        // assert_that!(repo.clone().name, is(equal_to(foo)));
         Ok(())
     }
 }

--- a/server/src/objects/repo.rs
+++ b/server/src/objects/repo.rs
@@ -65,13 +65,14 @@ mod tests {
     fn creates_repo() -> Result<()> {
         let fakehub = FakeHub::default();
         let github = fakehub.main();
-        // let mut jeff = github.user("jeff").expect("Failed to get user").clone();
-        // let foo = String::from("foo");
-        // Repo::new(foo.clone(), false).create_for(&mut jeff);
-        // assert_that!(jeff.repos.len(), is(equal_to(1)));
-        // let repos = jeff.repos;
-        // let repo = repos.first().expect("Failed to get repo");
-        // assert_that!(repo.clone().name, is(equal_to(foo)));
+        let github = github.lock().expect("Failed to lock");
+        let mut jeff = github.user("jeff").expect("Failed to get user").clone();
+        let foo = String::from("foo");
+        Repo::new(foo.clone(), false).create_for(&mut jeff);
+        assert_that!(jeff.repos.len(), is(equal_to(1)));
+        let repos = jeff.repos;
+        let repo = repos.first().expect("Failed to get repo");
+        assert_that!(repo.clone().name, is(equal_to(foo)));
         Ok(())
     }
 }

--- a/server/src/objects/user.rs
+++ b/server/src/objects/user.rs
@@ -73,7 +73,8 @@ impl User {
     ///
     /// let fakehub = &mut FakeHub::default();
     /// let github = fakehub.main();
-    /// // User::new(String::from("foo")).register_in(github, fakehub).expect("Failed to register user");
+    /// let mut locked = github.lock().expect("Failed to lock GitHub");
+    /// User::new(String::from("foo")).register_in(&mut locked, fakehub).expect("Failed to register user");
     ///```
     pub fn register_in(
         &mut self,

--- a/server/src/objects/user.rs
+++ b/server/src/objects/user.rs
@@ -262,14 +262,15 @@ mod tests {
 
     #[test]
     fn registers_in_github() -> Result<()> {
-        let mut fakehub = FakeHub::default();
+        let fakehub = FakeHub::default();
         let github = fakehub.main();
+        let mut github = github.lock().expect("Failed to lock");
         let foo = String::from("foo");
-        // User::new(foo.clone())
-        //     .register_in(github, fakehub)
-        //     .expect("Failed to register user");
-        // let pulled = github.users.get(&foo).expect("Failed to get user");
-        // assert_that!(pulled.clone().login, is(equal_to(foo)));
+        User::new(foo.clone())
+            .register_in(&mut github, &fakehub)
+            .expect("Failed to register user");
+        let pulled = github.users.get(&foo).expect("Failed to get user");
+        assert_that!(pulled.clone().login, is(equal_to(foo)));
         Ok(())
     }
 
@@ -277,40 +278,43 @@ mod tests {
     #[test]
     fn panics_when_already_registered() {
         let fakehub = FakeHub::default();
-        // let mut github = fakehub.clone().main();
-        // User::new(String::from("jeff"))
-        //     .register_in(&mut github, fakehub)
-        //     .expect("Failed to register user");
+        let github = fakehub.main();
+        let mut github = github.lock().expect("Failed to lock");
+        User::new(String::from("jeff"))
+            .register_in(&mut github, &fakehub)
+            .expect("Failed to register user");
     }
 
     #[test]
     fn registers_with_extra() -> Result<()> {
         let fakehub = FakeHub::default();
-        // let mut github = fakehub.clone().main();
-        // User::new(String::from("foo"))
-        //     .register_in(&mut github, fakehub)
-        //     .expect("Failed to register user");
-        // let user = github.users.get("foo").expect("Failed to get user");
-        // let url = user.extra.get("url").expect("Failed to read property");
-        // assert_that!(url.as_str(), is(equal_to(Some("localhost/users/foo"))));
-        // assert_that!(user.extra.len(), is(equal_to(31)));
+        let github = fakehub.main();
+        let mut github = github.lock().expect("Failed to lock");
+        User::new(String::from("foo"))
+            .register_in(&mut github, &fakehub)
+            .expect("Failed to register user");
+        let user = github.users.get("foo").expect("Failed to get user");
+        let url = user.extra.get("url").expect("Failed to read property");
+        assert_that!(url.as_str(), is(equal_to(Some("localhost/users/foo"))));
+        assert_that!(user.extra.len(), is(equal_to(31)));
         Ok(())
     }
 
     #[test]
     #[allow(clippy::unwrap_used)]
     fn registers_on_instance_with_predefined_start() -> Result<()> {
-        // let fakehub = FakeHub::new(Utc.with_ymd_and_hms(2024, 9, 1, 9, 10, 11).unwrap());
-        // let mut github = fakehub.clone().main();
-        // User::new(String::from("foo"))
-        //     .register_in(&mut github, fakehub)
-        //     .expect("Failed to register user");
-        // let user = github.users.get("foo").expect("Failed to get user");
-        // let id = user.extra.get("node_id").expect("Failed to read property");
-        // assert_that!(
-        //     id.as_str(),
-        //     is(equal_to(Some("305be946d516494d20c7c10f6d0020f9")))
-        // );
+        let fakehub = FakeHub::new(Utc.with_ymd_and_hms(2024, 9, 1, 9, 10, 11).unwrap());
+        let github = fakehub.main();
+        let mut github = github.lock().expect("Failed to lock");
+        User::new(String::from("foo"))
+            .register_in(&mut github, &fakehub)
+            .expect("Failed to register user");
+        let user = github.users.get("foo").expect("Failed to get user");
+        let id = user.extra.get("node_id").expect("Failed to read property");
+        assert_that!(
+            id.as_str(),
+            is(equal_to(Some("305be946d516494d20c7c10f6d0020f9")))
+        );
         Ok(())
     }
 }

--- a/server/src/objects/user.rs
+++ b/server/src/objects/user.rs
@@ -71,14 +71,14 @@ impl User {
     /// use fakehub_server::objects::fakehub::FakeHub;
     /// use fakehub_server::objects::user::User;
     ///
-    /// let fakehub = FakeHub::default();
-    /// let mut github = fakehub.clone().main().clone();
-    /// User::new(String::from("foo")).register_in(&mut github, fakehub).expect("Failed to register user");
+    /// let fakehub = &mut FakeHub::default();
+    /// let github = fakehub.main();
+    /// // User::new(String::from("foo")).register_in(github, fakehub).expect("Failed to register user");
     ///```
     pub fn register_in(
         &mut self,
         github: &mut GitHub,
-        instance: FakeHub,
+        instance: &FakeHub,
     ) -> Result<(), String> {
         match github.user(&self.login) {
             Some(u) => Err(format!("User with login @{} already exists!", u.login)),
@@ -262,14 +262,14 @@ mod tests {
 
     #[test]
     fn registers_in_github() -> Result<()> {
-        let fakehub = FakeHub::default();
-        let mut github = fakehub.clone().main();
+        let mut fakehub = FakeHub::default();
+        let github = fakehub.main();
         let foo = String::from("foo");
-        User::new(foo.clone())
-            .register_in(&mut github, fakehub)
-            .expect("Failed to register user");
-        let pulled = github.users.get(&foo).expect("Failed to get user");
-        assert_that!(pulled.clone().login, is(equal_to(foo)));
+        // User::new(foo.clone())
+        //     .register_in(github, fakehub)
+        //     .expect("Failed to register user");
+        // let pulled = github.users.get(&foo).expect("Failed to get user");
+        // assert_that!(pulled.clone().login, is(equal_to(foo)));
         Ok(())
     }
 
@@ -277,40 +277,40 @@ mod tests {
     #[test]
     fn panics_when_already_registered() {
         let fakehub = FakeHub::default();
-        let mut github = fakehub.clone().main();
-        User::new(String::from("jeff"))
-            .register_in(&mut github, fakehub)
-            .expect("Failed to register user");
+        // let mut github = fakehub.clone().main();
+        // User::new(String::from("jeff"))
+        //     .register_in(&mut github, fakehub)
+        //     .expect("Failed to register user");
     }
 
     #[test]
     fn registers_with_extra() -> Result<()> {
         let fakehub = FakeHub::default();
-        let mut github = fakehub.clone().main();
-        User::new(String::from("foo"))
-            .register_in(&mut github, fakehub)
-            .expect("Failed to register user");
-        let user = github.users.get("foo").expect("Failed to get user");
-        let url = user.extra.get("url").expect("Failed to read property");
-        assert_that!(url.as_str(), is(equal_to(Some("localhost/users/foo"))));
-        assert_that!(user.extra.len(), is(equal_to(31)));
+        // let mut github = fakehub.clone().main();
+        // User::new(String::from("foo"))
+        //     .register_in(&mut github, fakehub)
+        //     .expect("Failed to register user");
+        // let user = github.users.get("foo").expect("Failed to get user");
+        // let url = user.extra.get("url").expect("Failed to read property");
+        // assert_that!(url.as_str(), is(equal_to(Some("localhost/users/foo"))));
+        // assert_that!(user.extra.len(), is(equal_to(31)));
         Ok(())
     }
 
     #[test]
     #[allow(clippy::unwrap_used)]
     fn registers_on_instance_with_predefined_start() -> Result<()> {
-        let fakehub = FakeHub::new(Utc.with_ymd_and_hms(2024, 9, 1, 9, 10, 11).unwrap());
-        let mut github = fakehub.clone().main();
-        User::new(String::from("foo"))
-            .register_in(&mut github, fakehub)
-            .expect("Failed to register user");
-        let user = github.users.get("foo").expect("Failed to get user");
-        let id = user.extra.get("node_id").expect("Failed to read property");
-        assert_that!(
-            id.as_str(),
-            is(equal_to(Some("305be946d516494d20c7c10f6d0020f9")))
-        );
+        // let fakehub = FakeHub::new(Utc.with_ymd_and_hms(2024, 9, 1, 9, 10, 11).unwrap());
+        // let mut github = fakehub.clone().main();
+        // User::new(String::from("foo"))
+        //     .register_in(&mut github, fakehub)
+        //     .expect("Failed to register user");
+        // let user = github.users.get("foo").expect("Failed to get user");
+        // let id = user.extra.get("node_id").expect("Failed to read property");
+        // assert_that!(
+        //     id.as_str(),
+        //     is(equal_to(Some("305be946d516494d20c7c10f6d0020f9")))
+        // );
         Ok(())
     }
 }


### PR DESCRIPTION
In this pull I've fixed bug with broken user registration via `Arc<Mutex<GitHub>>`, introduced new tests to catch this problem in the future.

closes #174 
History:
- **feat(#174): works**
- **feat(#174): enable tests**
- **feat(#174): enable repo tests**
- **feat(#174): enable fakehub tests**
- **feat(#174): enable doc tests**
- **feat(#174): clean for check**
- **feat(#174): test**
- **feat(#174): registers_with_extra_fields**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing thread safety in the `FakeHub` structure by using `Arc<Mutex<GitHub>>`, ensuring concurrent access is managed properly. Additionally, it refactors various functions and updates user handling to improve reliability and maintainability.

### Detailed summary
- Changed `github` in `FakeHub` to `Arc<Mutex<GitHub>>` for thread safety.
- Updated `main()` method to return `Arc<Mutex<GitHub>>`.
- Refactored user handling in multiple handlers to lock the GitHub instance before accessing users.
- Modified `Coordinates` struct to hold a reference to `FakeHub`.
- Adjusted method signatures to accept references where appropriate.
- Enhanced tests to validate user registration and properties.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->