### PR TITLE
feat(#54): parametrized path in latex.rs

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -52,6 +52,7 @@ md5 = "0.7.0"
 chrono = "0.4.38"
 rand = "0.8.5"
 regex = "1.10.6"
+parameterized = "2.0.0"
 
 [features]
 mirror_release = []

--- a/server/src/report/latex.rs
+++ b/server/src/report/latex.rs
@@ -46,11 +46,11 @@ pub fn template(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use crate::report::latex::template;
     use anyhow::Result;
     use hamcrest::{equal_to, is, HamcrestMatcher};
     use parameterized::parameterized;
+    use std::path::Path;
 
     #[parameterized(
         path = {

--- a/server/src/report/latex.rs
+++ b/server/src/report/latex.rs
@@ -35,27 +35,30 @@ use std::path::Path;
 /// # Examples
 ///
 /// ```
+/// use std::path::Path;
 /// use crate::fakehub_server::report::latex::template;
-/// let content = template("resources/report.tex");
+/// let content = template(Path::new("resources/report.tex"));
 /// print!("{content}")
 /// ```
-pub fn template(path: &str) -> String {
-    return fs::read_to_string(Path::new(path)).expect("template should be read from");
+pub fn template(path: &Path) -> String {
+    fs::read_to_string(path).expect("template should be read from")
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
     use crate::report::latex::template;
     use anyhow::Result;
     use hamcrest::{equal_to, is, HamcrestMatcher};
+    use parameterized::parameterized;
 
-    #[test]
-    // @todo #41:60min Add support of @ExtendsWith from JUnit in order to pass expected as test parameter.
-    //  We should use extensions in order to pass expected as parameters into
-    //  test. If there is no crate with such functionality - let's develop and
-    //  release one.
-    fn returns_template_content() -> Result<()> {
-        let content = template("resources/report.tex");
+    #[parameterized(
+        path = {
+            &Path::new("resources/report.tex")
+        }
+    )]
+    fn returns_template_content(path: &Path) -> Result<()> {
+        let content = template(path);
         let expected = r"\usepackage{to-be-determined}
 \documentclass[12pt]{article}
 \begin{document}


### PR DESCRIPTION
closes #54

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `template` function to accept a `&Path` instead of a `&str`, enhancing type safety. It also introduces the `parameterized` crate for testing.

### Detailed summary
- Added `parameterized` crate dependency in `server/Cargo.toml`.
- Updated documentation in `server/src/report/latex.rs` to reflect changes in `template`.
- Changed `template` function signature from `&str` to `&Path`.
- Modified test function to use `Path` for better parameterization.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->