### PR TITLE
feat(#157): test tagging via tagrs

### DIFF
--- a/.github/workflows/just.yml
+++ b/.github/workflows/just.yml
@@ -67,4 +67,4 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: rustup component add --toolchain nightly-x86_64-apple-darwin rustfmt
       - run: just install
-      - run: just full
+      - run: just full "deep,fast"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,6 +51,7 @@ tracing-subscriber = "0.3.18"
 tracing = "0.1.40"
 reqwest = "0.12.7"
 defer = "0.2.1"
+tagrs = "0.0.2"
 
 [features]
 default = ["cli"]

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -29,7 +29,9 @@ mod tests {
     use std::str;
     #[cfg_attr(target_os = "windows", allow(unused_imports))]
     use std::time::Duration;
+    use tagrs::tag;
 
+    #[tag("deep")]
     #[test]
     fn outputs_help() -> Result<()> {
         let assertion = Command::cargo_bin("fakehub")?.arg("--help").assert();
@@ -43,6 +45,7 @@ mod tests {
         Ok(())
     }
 
+    #[tag("deep")]
     #[test]
     fn outputs_start_opts() -> Result<()> {
         let assertion = Command::cargo_bin("fakehub")?

--- a/justfile
+++ b/justfile
@@ -26,9 +26,9 @@ install:
   cargo install killport
 
 # Full build.
-full:
+full tests="fast":
   just gen
-  just build
+  just build "{{tests}}"
 
 # Generate code.
 gen:
@@ -39,15 +39,15 @@ gen:
       openapi-generator-cli generate -i github.yml -g rust -o .
 
 # Build the project.
-build:
-  cargo clean
-  just test
+build tests="fast":
+  just test "{{tests}}"
   just check
   cargo build
 
 # Run tests.
-test:
-  cargo test
+test which="fast":
+  cargo clean
+  TTAG="{{which}}" cargo test
 
 # Check the quality of code.
 check:
@@ -61,7 +61,7 @@ rultor:
   cd github-mirror && \
     sudo npm install @openapitools/openapi-generator-cli@2.13.7 -g && \
       sudo openapi-generator-cli generate -i github.yml -g rust -o .
-  cargo --color=never test
+  TTAG="deep,fast" cargo --color=never test
   cargo +nightly fmt --check -- --color=never
   cargo machete
   cargo doc --no-deps

--- a/server/src/report/latex.rs
+++ b/server/src/report/latex.rs
@@ -46,11 +46,11 @@ pub fn template(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use crate::report::latex::template;
     use anyhow::Result;
     use hamcrest::{equal_to, is, HamcrestMatcher};
     use parameterized::parameterized;
+    use std::path::Path;
 
     #[parameterized(
         path = {


### PR DESCRIPTION
closes #157

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new dependency, updates CI configurations, and modifies the `justfile` for improved build and test processes. It also adds new test cases and applies a tagging system for better organization.

### Detailed summary
- Added `tagrs` dependency in `cli/Cargo.toml`.
- Updated GitHub Actions workflow to run `just full "deep,fast"`.
- Introduced two new tests (`outputs_help`, `outputs_start_opts`) tagged as "deep" in `cli/tests/integration_test.rs`.
- Modified `full` target in `justfile` to accept `tests` parameter.
- Updated `build` target to take `tests` parameter.
- Changed `test` target to use a `which` parameter.
- Updated Rultor merge script to run tests with the tag "deep,fast".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->