### PR TITLE
fix(#189): no dry-run for dependant packages

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -57,10 +57,6 @@ release:
     git commit -am "${tag}"
     ls -a ../
     mkdir -p ~/.cargo && cp ../credentials ~/.cargo
-    cargo --color=never publish -p github-mirror --dry-run
-    cargo --color=never publish -p fakehub-server --features "mirror_release" --dry-run
-    cargo --color=never publish -p fakehub --dry-run
-    echo "Packages ready for upload to crates.io"
     cargo --color=never publish -p github-mirror
     cargo --color=never publish -p fakehub-server --features "mirror_release"
     cargo --color=never publish -p fakehub


### PR DESCRIPTION
ref #189 

see: https://github.com/crate-ci/cargo-release/issues/691

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `.rultor.yml` file to remove the `--dry-run` option from the `cargo publish` commands, allowing the actual publishing of the packages instead of just simulating the process.

### Detailed summary
- Removed `--dry-run` option from `cargo publish` for `github-mirror`, `fakehub-server`, and `fakehub`.
- Added actual publishing commands for the specified packages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->