### PR TITLE
feat(#197): --version, -v

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -19,7 +19,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-use clap::{Parser, Subcommand, ArgAction};
+use clap::{ArgAction, Parser, Subcommand};
 
 // @todo #41:15min Add --report argument.
 //  Let's add --report option for generating reports in desired formats:

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -19,18 +19,17 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ArgAction};
 
 // @todo #41:15min Add --report argument.
 //  Let's add --report option for generating reports in desired formats:
 //  We should support following formats: xml, tex, and txt. User should have
 //  ability to generate report in multiple formats as well: --report tex,xml,txt.
-// @todo #79:25min Add --v option for verbose output.
-//  Let's add --v option for verbose output and debug logs. When this option is
-//  passed, we should show debug logs too.
 #[derive(Parser, Debug)]
-#[command(name = "fakehub")]
+#[command(name = "fakehub", version = env!("CARGO_PKG_VERSION"))]
 pub(crate) struct Args {
+    #[arg(short = 'v', action = ArgAction::Version)]
+    v: Option<bool>,
     #[command(subcommand)]
     pub(crate) command: Command,
 }

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -47,6 +47,25 @@ mod tests {
 
     #[tag("deep")]
     #[test]
+    fn outputs_version() -> Result<()> {
+        let assertion = Command::cargo_bin("fakehub")?.arg("--version").assert();
+        let bytes = assertion.get_output().stdout.as_slice();
+        let output = str::from_utf8(bytes)?;
+        assert!(output.contains(env!("CARGO_PKG_VERSION")));
+        Ok(())
+    }
+    
+    #[test]
+    fn outputs_version_from_short() -> Result<()> {
+        let assertion = Command::cargo_bin("fakehub")?.arg("-v").assert();
+        let bytes = assertion.get_output().stdout.as_slice();
+        let output = str::from_utf8(bytes)?;
+        assert!(output.contains(env!("CARGO_PKG_VERSION")));
+        Ok(())
+    }
+
+    #[tag("deep")]
+    #[test]
     fn outputs_start_opts() -> Result<()> {
         let assertion = Command::cargo_bin("fakehub")?
             .arg("start")

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -54,7 +54,7 @@ mod tests {
         assert!(output.contains(env!("CARGO_PKG_VERSION")));
         Ok(())
     }
-    
+
     #[test]
     fn outputs_version_from_short() -> Result<()> {
         let assertion = Command::cargo_bin("fakehub")?.arg("-v").assert();


### PR DESCRIPTION
closes #197

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `fakehub` CLI by adding version output tests and modifying the argument parser to include a version flag. 

### Detailed summary
- Added a test function `outputs_version` to check the output of the `--version` flag.
- Added a test function `outputs_version_from_short` to check the output of the `-v` flag.
- Updated the `Args` struct to include a version argument with `ArgAction::Version`. 
- Modified the `command` attribute to include the version in the command metadata.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->