### PR TITLE
feat(#187): quick start

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -27,4 +27,4 @@ default: true
 MD013:
   line_length: 80
   tables: false
-  code: false
+  code_blocks: false

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -27,3 +27,4 @@ default: true
 MD013:
   line_length: 80
   tables: false
+  code: false

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ curl -X POST \
   http://localhost:$port/login
 ```
 
-This should generate you an access token to fakehub [API](#supported-api).
+This should generate you an access token to fakehub API.
 
 ### GitHub objects
 
@@ -140,7 +140,6 @@ Here is the [contribution vitals][Zerocracy Vitals], made by [zerocracy/judges-a
 (updated every hour!).
 
 [GitHub REST API]: https://docs.github.com/en/rest?apiVersion=2022-11-28
-[homebrew]: https://brew.sh
 [fakehub-crate]: https://crates.io/crates/fakehub
 [LaTeX]: https://en.wikipedia.org/wiki/LaTeX
 [XML]: https://en.wikipedia.org/wiki/XML

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ API server somehow. We offer a fully functioning mock version of a GitHub REST
 API, which would support all functions, but work locally, with absolutely no
 connection to GitHub.
 
-## How to use?
+## Quick start
 
 First, install it from [crate][fakehub-crate]:
 
@@ -29,21 +29,46 @@ First, install it from [crate][fakehub-crate]:
 cargo install fakehub
 ```
 
-or with [homebrew] (macOS):
+Then, create a simple test, `test.sh`:
 
 ```bash
-brew install fakehub
+{
+  fakehub start -d
+  out="$(curl -s 'http://localhost:3000/users/jeff' | jq -r '.login')"
+  expected="jeff"
+  if [ "$out" == $expected ]; then
+    echo "Test passed!"
+  else
+    echo "Login '$out' does not match with expected: '$expected'"
+    exit 1
+  fi
+  fakehub stop
+}
 ```
 
-Then, run it:
+And run it:
 
 ```bash
-fakehub start --port 8080
+sh test.sh
+```
+
+You should be able to see this:
+
+```text
+2024-10-15T15:14:33.469924Z  INFO fakehub: Starting server on port 3000
+2024-10-15T15:14:33.470238Z  INFO fakehub: Server is running in detached mode on port 3000
+2024-10-15T15:14:33.470247Z  INFO fakehub_server::sys::sys_info: OS: macos
+2024-10-15T15:14:33.470251Z  INFO fakehub_server::sys::sys_info: PID: 11751
+Test passed!
+2024-10-15T15:14:33.486892Z  INFO fakehub: Stopping fakehub...
+2024-10-15T15:14:33.518901Z  INFO fakehub::sys::kill_unix: Port 3000 killed
+2024-10-15T15:14:33.518913Z  INFO fakehub: fakehub stopped
 ```
 
 Table of contents:
 
 * [Overview](#overview)
+* [Request Format](#request-format)
 * [GitHub Objects](#github-objects)
 * [CLI Options](#cli-options)
 
@@ -81,19 +106,6 @@ curl -X POST \
 ```
 
 This should generate you an access token to fakehub [API](#supported-api).
-
-To stop a server, run:
-
-```bash
-fakehub stop
-```
-
-### Supported API
-
-We support the following list of "fake" versions of GitHub endpoints:
-
-| Operation | GitHub REST API Endpoint | Supported in fakehub |
-|-----------|--------------------------|----------------------|
 
 ### GitHub Objects
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Test passed!
 2024-10-15T15:14:33.518913Z  INFO fakehub: fakehub stopped
 ```
 
-Table of contents:
+## Table of contents
 
 * [Overview](#overview)
-* [Request Format](#request-format)
-* [GitHub Objects](#github-objects)
-* [CLI Options](#cli-options)
+* [Request format](#request-format)
+* [GitHub objects](#github-objects)
+* [CLI options](#cli-options)
 
 ### Overview
 
@@ -80,7 +80,7 @@ fakehub stores all the data in memory. When [request arrives](#request-format),
 we query the storage, transform objects into GitHub API-compatible format
 ([JSON]) and give it to you.
 
-### Request Format
+### Request format
 
 fakehub supports the format specified in [GitHub REST API docs][GitHub REST API].
 For instance, if you want to use [Get a repository][GitHub REST API Get Repo]
@@ -107,11 +107,11 @@ curl -X POST \
 
 This should generate you an access token to fakehub [API](#supported-api).
 
-### GitHub Objects
+### GitHub objects
 
 TBD..
 
-### CLI Options
+### CLI options
 
 You can use the following options within `fakehub` command-line tool:
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ You can use the following options within `fakehub` command-line tool:
 | `-p`, `--port`    | int     | `3000`  | Port to run fakehub server on.                                                                            |
 | `-v`, `--verbose` | boolean | `false` | Verbose run output, i.e. debug logs, etc.                                                                 |
 | `-d`,  `--detach` | boolean | `false` | Run fakehub server in detached mode.                                                                      |
-| `report`          | boolean | `false` | Generate report after fakehub shutdown.                                                                   |
-| `report-format`   | string  | -       | Generated report format. Possible values: `latex` for [LaTeX], `xml` for [XML], and `txt` for plain text. |
+| `-i`, `--init`    | string  | -       | Path to file or directory with initial state.                                                             |
+| `-r`, `--report`  | boolean | `false` | Generate report after fakehub shutdown.                                                                   |
+| `--report-format` | string  | -       | Generated report format. Possible values: `latex` for [LaTeX], `xml` for [XML], and `txt` for plain text. |
 
 ## How to contribute?
 

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -55,6 +55,6 @@ pub(crate) struct StartArgs {
     #[arg(short, long, default_value = "false")]
     pub(crate) detach: bool,
     /// Path to file or directory with initial state.
-    #[arg(long, default_value = "")]
+    #[arg(short, long, default_value = "")]
     pub(crate) init: String,
 }

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -82,6 +82,7 @@ mod tests {
         assert!(output.contains("-d"));
         assert!(output.contains("--detach"));
         assert!(output.contains("Run in detach mode"));
+        assert!(output.contains("-i"));
         assert!(output.contains("--init"));
         assert!(output.contains("Path to file or directory with initial state"));
         Ok(())


### PR DESCRIPTION
closes #187
History:
- **feat(#187): quick start**
- **feat(#187): toc, lower**
- **feat(#187): short**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `fakehub` CLI by updating command-line options, improving the README documentation for user guidance, and modifying the configuration for Markdown linting.

### Detailed summary
- Updated `detach` argument in `cli/src/args.rs` to accept a short flag `-d`.
- Added a short flag `-i` for the `init` argument.
- Revised README section headers and improved usage instructions.
- Included a sample test script in the README.
- Adjusted the Markdown linting configuration to disable code block length restriction.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->