### PR TITLE
chore: bump macOS to 14

### DIFF
--- a/.github/workflows/just.yml
+++ b/.github/workflows/just.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-14 ]
+        os: [ ubuntu-22.04, windows-2022, macos-13 ]
         just-version: [ "1.30.1" ]
         java: [ 21 ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the operating system version in the GitHub Actions workflow configuration for `just.yml`, changing it from `macos-12` to `macos-13`.

### Detailed summary
- Updated the `os` matrix in `.github/workflows/just.yml` from `macos-12` to `macos-13`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->